### PR TITLE
Makefile: find the module path using locate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 CFLAGS = `pkg-config --cflags libfm` `Magick-config --cflags`
 AM_LDFLAGS = `Magick-config --libs` -rpath /usr/lib -no-undefined -module -avoid-version
+modulepath=$(shell locate libfm/modules | head -n1 | tr -d "\n")
 
 all:
 	libtool --mode=compile gcc $(CFLAGS) -c pcmanfm-image-size-plugin.c
 	libtool --mode=link gcc $(AM_LDFLAGS) pcmanfm-image-size-plugin.lo -o pcmanfm-image-size-plugin.la
 
 install:
-	libtool --mode=install install -c pcmanfm-image-size-plugin.la /usr/lib/libfm/modules
-	libtool --finish /usr/lib/libfm/modules/
+	libtool --mode=install install -c pcmanfm-image-size-plugin.la $(modulepath)
+	libtool --finish $(modulepath)


### PR DESCRIPTION
It's not reliable but l think it's better than the fixed path.